### PR TITLE
Rename crates

### DIFF
--- a/src/Display.elm
+++ b/src/Display.elm
@@ -28,7 +28,7 @@ scene (w,h) isLocked texture person =
 
 entities : Response Texture -> Mat4 -> [Entity]
 entities response view =
-    let crate' = case response of
+    let crates = case response of
                    Success texture ->
                        [ crate texture view
                        , crate texture (translate3  10 0  10 view)
@@ -36,4 +36,4 @@ entities response view =
                        ]
                    _ -> []
     in  
-        ground view :: crate'
+        ground view :: crates


### PR DESCRIPTION
Just a bugbear: naming things with a ' (prime, apostrophe) is a mathy Haskellism, and it's often a sign that no thought has been put into the name. Sometimes it works, if x' is a transformed version of x and the transform is obvious (like, it's the whole purpose of the function, and the function itself is well-named -- the way you used h' and v' in Update.turn is a good example of that).

Especially for awesome i-wanna-fork-it sample code like this, to be read by new users, the fewer haskellisms the better ... hence this PR!
