### PR TITLE
Don't use Signal () for ports (build fix 0.13)

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -32,10 +32,10 @@ main =
 -- give up the lock. This code can all be removed if you want to do this
 -- differently.
 
-port requestPointerLock : Signal ()
+port requestPointerLock : Signal Bool
 port requestPointerLock =
-    dropWhen (lift2 (&&) Keyboard.shift isLocked) () Mouse.clicks
+    always True <~ dropWhen (lift2 (&&) Keyboard.shift isLocked) () Mouse.clicks
 
-port exitPointerLock : Signal ()
+port exitPointerLock : Signal Bool
 port exitPointerLock =
-    always () <~ keepIf (any (\x -> x == 27)) [] Keyboard.keysDown
+    always True <~ keepIf (any (\x -> x == 27)) [] Keyboard.keysDown


### PR DESCRIPTION
Using Signal () was never supported anyway according to the docs, and gives
a compile error with elm-0.13.
